### PR TITLE
Release 0.1.1 -- require aws version 5

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      version = ">=4.0.0, <6.0"
+      version = ">=5.0.0, <6.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
### Changed
- Restrict the aws provider to version 5 to support the `logging_config` block